### PR TITLE
Docs

### DIFF
--- a/docs/GETTING_STARTED_DOCKER.md
+++ b/docs/GETTING_STARTED_DOCKER.md
@@ -8,6 +8,7 @@ Before setting up ScrAIbe-WebUI with Docker, ensure you have the following prere
 
 - **Docker**: Installed and running on your machine. You can download Docker from the official [Docker website](https://www.docker.com/get-started).
 - **Docker Compose**: Installed and running on your machine. You can download Docker Compose from the official [Docker Compose website](https://docs.docker.com/compose/install/).
+- **Nvidia GPU Support (Optional)**: If you want to use GPU, ensure you have the Nvidia Container Toolkit installed and configured on your machine. You can find installation instructions on the [Nvidia Container Toolkit website](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
 
 ## Install ScrAIbe-WebUI Using Docker
 

--- a/docs/GETTING_STARTED_DOCKER.md
+++ b/docs/GETTING_STARTED_DOCKER.md
@@ -45,27 +45,22 @@ Here is an example of what your docker-compose.yml file might look like:
 
 ```yaml
 services:
-  scraibe:
-    # you can set a UID/GID in an .env file
-    user: "${UID}:${GID}"
-    entrypoint: ./run_docker.sh
-    build: .
-    environment: 
-      - AUTOT_CACHE=/data/models/
-    container_name: scraibe_large
-    ports:
-      - '7860:7860'
-    volumes: 
-      - type: bind
-        source: data/
-        target: /data/
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
+    scraibe:
+      # you can set a UID/GID in an .env file
+      # user: "${UID}:${GID}"
+      build: .
+      container_name: scraibe-webui
+      ports:
+        - '7860:7860'
+      volumes: 
+        - ./data:/data 
+      deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                count: 1
+                capabilities: [gpu]
 ```
 
 ## Using the Pre-built Image from Docker Hub
@@ -77,7 +72,7 @@ If you prefer to use the pre-built image available on Docker Hub, you can pull a
 Run the Docker container using the pre-built image:
 
 ```bash
-docker run -d --name scraibe-webui -p 7860:7860 --gpus 'all' -v $(pwd)/data:/data hadr0n/scraibe-webui:latest_webui
+docker run -d --name scraibe-webui -p 7860:7860 --gpus 'all' -v $(pwd)/data:/data hadr0n/scraibe-webui
 ```
 
 Docker will automatically pull the image from Docker Hub if it is not already present on your system.

--- a/docs/GETTING_STARTED_DOCKER.md
+++ b/docs/GETTING_STARTED_DOCKER.md
@@ -52,7 +52,7 @@ services:
     build: .
     environment: 
       - AUTOT_CACHE=/data/models/
-    container_name: scraibe_large
+    container_name: scraibe-WebUI
     ports:
       - '7860:7860'
     volumes: 
@@ -77,7 +77,7 @@ If you prefer to use the pre-built image available on Docker Hub, you can pull a
 Run the Docker container using the pre-built image:
 
 ```bash
-docker run -d --name scraibe_webui -p 7860:7860 -v $(pwd)/data:/data hadr0n/scraibe
+docker run -d --name scraibe-webui -p 7860:7860 -v $(pwd)/data:/data hadr0n/scraibe-webui:latest
 ```
 
 Docker will automatically pull the image from Docker Hub if it is not already present on your system.


### PR DESCRIPTION
Fixed name of the container from `scraibe_webui` to `scraibe-webui`