### PR TITLE
Fix set scraibe webui version config yaml

### DIFF
--- a/scraibe_webui/utils/appconfigloader.py
+++ b/scraibe_webui/utils/appconfigloader.py
@@ -89,8 +89,9 @@ class AppConfigLoader(ConfigLoader):
                 bool: True if the key contains path-related substrings or the value contains file extensions, otherwise False.
             """
             
-            key_contains = ['scr', 'file', 'path']
+            key_contains = ['src', 'file', 'path']
             value_ends_with = ['.html', '.css', '.png', '.jpg', '.jpeg', '.svg']
+    
             if value is None:
                 return False
             else:
@@ -121,7 +122,7 @@ class AppConfigLoader(ConfigLoader):
         _footer_format_options : dict = _layout.get("footer_format_options")
         
         for key, value in _footer_format_options.items():
-                         
+            print(key, value)
             if _check_potential_path(key, value):
                 self.check_and_set_path(key)
                 self.add_to_allowed_paths(value)


### PR DESCRIPTION
Fixed issue where instead of checking for `src` in a string, it was trying to find `scr` in a string, but this is also contained in `scraibe`