### PR TITLE
run_docker.sh issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,10 @@ COPY scraibe_webui /app/src/scraibe_webui
 COPY pyproject.toml /app/src/pyproject.toml
 COPY LICENSE /app/src/LICENSE
 COPY run_docker.sh /app/run_docker.sh
-RUN chmod +x /app/run_docker.sh && \
+RUN sed -i 's/\r$//' /app/run_docker.sh && \
+    chmod +x /app/run_docker.sh && \
     mkdir /data
+
 
 #Installing all necessary Dependencies and Running the Application with a personalised Hugging-Face-Token
 RUN apt update -y && apt upgrade -y && \

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-file=/app/scraibe_webui/misc/config.yaml
+file=/app/src/scraibe_webui/misc/config.yaml
 dest=/data/config.yaml
 # copy only if target file is not present
 if [ ! -e "$dest" ]; then


### PR DESCRIPTION
Hello,
slight modifications to run_docker.sh and DockerFile.
First of all, in DockerFile, the script was not executing correctly. This is because text files under Windows use different line endings to those under Unix/Linux. This is a protective measure to avoid this type of problem in the future.
Finally, for run_docker.sh, the app files including config.yaml are located in /app/src/...... Here, however, it immediately accesses /app/scraibe_webui/...
That's it 😊